### PR TITLE
Show default keys in help

### DIFF
--- a/elvolantevirtual/main.py
+++ b/elvolantevirtual/main.py
@@ -927,7 +927,11 @@ def main(prog: str) -> int:
     :param prog: name of the program to be displayed in the help
     :return: exit code
     """
-    parser = argparse.ArgumentParser(prog=prog, description=__doc__)
+    parser = argparse.ArgumentParser(
+        prog=prog,
+        description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     parser.add_argument(
         "--version", help="show the current version and exit", action="store_true"
     )


### PR DESCRIPTION
We show the defaults in the help message so that the users can look up what the keys are in case they do not change anything. Otherwise, the users are in the dark what keys are going to be issued.